### PR TITLE
Add Support for `formatChars` Prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Simple masks can be defined as strings. The following characters will define mas
 
 Any format character can be escaped with a backslash.<br /><br />
 
-More complex masks can be defined as an array of regular expressions and constant characters. Additionally, you can define custom format characters using the [`formatChars`](#formatchars) prop replace the default format characters.
+More complex masks can be defined as an array of regular expressions and constant characters. Additionally, you can define custom format characters using the [`formatChars`](#formatchars) prop to replace the default format characters.
 
 ```jsx
 // Canadian postal code mask

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ function DateInput(props) {
 |          **[`alwaysShowMask`](#alwaysshowmask)**          |            `{Boolean}`            | `false` | Whether mask prefix and placeholder should be displayed when input is empty and has no focus |
 | **[`beforeMaskedStateChange`](#beforemaskedstatechange)** |           `{Function}`            |         | Function to modify value and selection before applying mask                                  |
 |                **[`children`](#children)**                |         `{ReactElement}`          |         | Custom render function for integration with other input components                           |
+|              **[`formatChars`](#formatchars)**            |    `{Object<String, RegExp>}`     |         | Custom format character definitions                                                          |
 
 ### `mask`
 
@@ -70,7 +71,7 @@ Simple masks can be defined as strings. The following characters will define mas
 
 Any format character can be escaped with a backslash.<br /><br />
 
-More complex masks can be defined as an array of regular expressions and constant characters.
+More complex masks can be defined as an array of regular expressions and constant characters. Additionally, you can define custom format characters using the [`formatChars`](#formatchars) prop replace the default format characters.
 
 ```jsx
 // Canadian postal code mask
@@ -138,6 +139,38 @@ return (
 ```
 
 Please note that `beforeMaskedStateChange` executes more often than `onChange` and must be pure.
+
+### `formatChars`
+
+The `formatChars` prop allows you to define custom format characters for your mask patterns. By default, the component uses the following format characters:
+
+| Character | Allowed input |
+| :-------: | :-----------: |
+|     9     |      0-9      |
+|     a     |   a-z, A-Z    |
+|    \*     | 0-9, a-z, A-Z |
+
+When you provide a `formatChars` object, it **completely replaces** the default format characters. This means that if you want to use any of the default characters, you must redefine them in your custom `formatChars` object.
+
+```jsx
+// Custom format characters
+const customFormatChars = {
+  w: /[a-z]/,        // lowercase letters only
+  W: /[A-Z]/,        // uppercase letters only
+  '#': /[0-9]/,      // digits only
+};
+
+<InputMask
+  mask="WWWW-####-wwww"
+  placeholder="ABCD-1234-efgh"
+  formatChars={customFormatChars}
+/>
+```
+
+In the example above, we've defined custom format characters:
+- `W` accepts only uppercase letters
+- `#` accepts only digits
+- `w` accepts only lowercase letters
 
 ### `children`
 

--- a/dev/index.js
+++ b/dev/index.js
@@ -3,14 +3,6 @@ import React, { useState } from "react";
 import ReactDOM from "react-dom";
 import InputMask from "../src";
 
-const customFormatChars = {
-  w: /[a-z]/, // lowercase letters only
-  W: /[A-Z]/, // uppercase letters only
-  "#": /[0-9]/, // digits only
-  A: /[A-Za-z]/, // any letter
-  "*": /[A-Za-z0-9]/, // alphanumeric (overriding default)
-};
-
 function Input() {
   const [value, setValue] = useState("");
 
@@ -18,15 +10,7 @@ function Input() {
     setValue(event.target.value);
   };
 
-  return (
-    <InputMask
-      value={value}
-      onChange={onChange}
-      mask="WWWW-####-AAAA"
-      placeholder="ABCD-1234-efgh"
-      formatChars={customFormatChars}
-    />
-  );
+  return <InputMask mask="99/99/9999" value={value} onChange={onChange} />;
 }
 
 function escapeHtml(unsafe) {

--- a/dev/index.js
+++ b/dev/index.js
@@ -3,6 +3,14 @@ import React, { useState } from "react";
 import ReactDOM from "react-dom";
 import InputMask from "../src";
 
+const customFormatChars = {
+  w: /[a-z]/, // lowercase letters only
+  W: /[A-Z]/, // uppercase letters only
+  "#": /[0-9]/, // digits only
+  A: /[A-Za-z]/, // any letter
+  "*": /[A-Za-z0-9]/, // alphanumeric (overriding default)
+};
+
 function Input() {
   const [value, setValue] = useState("");
 
@@ -10,7 +18,15 @@ function Input() {
     setValue(event.target.value);
   };
 
-  return <InputMask mask="99/99/9999" value={value} onChange={onChange} />;
+  return (
+    <InputMask
+      value={value}
+      onChange={onChange}
+      mask="WWWW-####-AAAA"
+      placeholder="ABCD-1234-efgh"
+      formatChars={customFormatChars}
+    />
+  );
 }
 
 function escapeHtml(unsafe) {

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,7 @@ const InputMask = forwardRef(function InputMask(props, forwardedRef) {
     children,
     mask,
     maskPlaceholder,
+    formatChars,
     beforeMaskedStateChange,
     ...restProps
   } = props;
@@ -27,7 +28,7 @@ const InputMask = forwardRef(function InputMask(props, forwardedRef) {
   validateMaxLength(props);
   validateMaskPlaceholder(props);
 
-  const maskUtils = new MaskUtils({ mask, maskPlaceholder });
+  const maskUtils = new MaskUtils({ mask, maskPlaceholder, formatChars });
 
   const isMasked = !!mask;
   const isEditable = !restProps.disabled && !restProps.readOnly;
@@ -311,6 +312,7 @@ InputMask.propTypes = {
     ),
   ]),
   maskPlaceholder: PropTypes.string,
+  formatChars: PropTypes.objectOf(PropTypes.instanceOf(RegExp)),
   onFocus: PropTypes.func,
   onBlur: PropTypes.func,
   onChange: PropTypes.func,

--- a/src/utils/parse-mask.js
+++ b/src/utils/parse-mask.js
@@ -1,6 +1,7 @@
 import { defaultFormatChars } from "../constants";
 
-const parseMask = ({ mask, maskPlaceholder }) => {
+const parseMask = ({ mask, maskPlaceholder, formatChars }) => {
+  const chars = formatChars || defaultFormatChars;
   const permanents = [];
 
   if (!mask) {
@@ -20,7 +21,7 @@ const parseMask = ({ mask, maskPlaceholder }) => {
       if (!isPermanent && character === "\\") {
         isPermanent = true;
       } else {
-        if (isPermanent || !defaultFormatChars[character]) {
+        if (isPermanent || !chars[character]) {
           permanents.push(parsedMaskString.length);
         }
         parsedMaskString += character;
@@ -30,7 +31,7 @@ const parseMask = ({ mask, maskPlaceholder }) => {
 
     mask = parsedMaskString.split("").map((character, index) => {
       if (permanents.indexOf(index) === -1) {
-        return defaultFormatChars[character];
+        return chars[character];
       }
       return character;
     });

--- a/tests/input/input.test.js
+++ b/tests/input/input.test.js
@@ -1407,4 +1407,19 @@ describe("react-input-mask", () => {
     await simulateInput(input, "EfGh");
     expect(input.value).to.equal("ABCD-1234-EfGh");
   });
+
+  it("should replace default formatChars when custom ones are provided", async () => {
+    const customFormatChars = {
+      W: /[A-Z]/,
+    };
+
+    const { input } = createInput(
+      <Input mask="999W" formatChars={customFormatChars} />,
+    );
+
+    await simulateFocus(input);
+    await simulateInput(input, "123A");
+    // '999' should remain since '9' is not defined in customFormatChars
+    expect(input.value).to.equal("999A");
+  });
 });

--- a/tests/input/input.test.js
+++ b/tests/input/input.test.js
@@ -1372,4 +1372,39 @@ describe("react-input-mask", () => {
     expect(getInputSelection(input).start).to.equal(5);
     expect(getInputSelection(input).end).to.equal(5);
   });
+
+  it("should handle custom formatChars prop", async () => {
+    const customFormatChars = {
+      W: /[A-Z]/, // uppercase letters only
+      "#": /[0-9]/, // digits only
+      A: /[A-Za-z]/, // any letter
+    };
+
+    const { input } = createInput(
+      <Input
+        mask="WWWW-####-AAAA"
+        placeholder="ABCD-1234-EfGh"
+        formatChars={customFormatChars}
+      />,
+    );
+
+    await simulateFocus(input);
+
+    await simulateInput(input, "abcd");
+    expect(input.value).to.equal("____-____-____");
+    await simulateInput(input, "ABCD");
+    expect(input.value).to.equal("ABCD-____-____");
+
+    await setCursorPosition(input, 5);
+    await simulateInput(input, "AbCd");
+    expect(input.value).to.equal("ABCD-____-____");
+    await simulateInput(input, "1234");
+    expect(input.value).to.equal("ABCD-1234-____");
+
+    await setCursorPosition(input, 10);
+    await simulateInput(input, "42");
+    expect(input.value).to.equal("ABCD-1234-____");
+    await simulateInput(input, "EfGh");
+    expect(input.value).to.equal("ABCD-1234-EfGh");
+  });
 });


### PR DESCRIPTION
This PR reintroduces support for the `formatChars` property, which was available in v2 but missing in v3. This addition significantly eases migration from v2 to v3 for codebases that rely heavily on this feature. Based on the votes in the old repository, it's clear that support for this feature is highly requested by the community - https://github.com/sanniassin/react-input-mask/issues/241

When `formatChars` is provided, it completely replaces the default format characters (9, a, *), giving users full control over the masking behavior, see example in updated README. This is a backward-compatible addition. If formatChars is not provided, the component continues to use the default format characters.